### PR TITLE
feat(#90): add loading tab by hash

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -47,8 +47,8 @@ import ThemeMixin from '../mixins/theme'
 export default {
   mixins: [ThemeMixin],
 
-  data: ({ tabs, tabId }) => ({
-    model: tabId(tabs[0]),
+  data: ({ hashTab, tabs, tabId }) => ({
+    model: hashTab || tabId(tabs[0]),
   }),
 
   props: {
@@ -56,6 +56,13 @@ export default {
       type: Array,
       required: true
     },
+  },
+
+  computed: {
+    hashTab: ({ $route }) =>
+      $route.hash
+        ? $route.hash.slice(1).split('-').slice(0, -1).join('-')
+        : undefined
   },
 
   methods: {
@@ -70,6 +77,10 @@ export default {
     tabId(tab, delta = 0) {
       return tab.id || `tab-${delta}`
     }
+  },
+
+  mounted() {
+    if (this.hashTab) this.model = this.hashTab
   },
 
   watch: {


### PR DESCRIPTION
Add support for hash links to load specified tab
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor: Enhanced Tab Navigation**

- New Feature: Tabs now support URL hash navigation. Users can directly navigate to a specific tab using the URL hash.
- Improvement: The initial tab selection is now more intuitive. If a valid hash is present in the URL, the corresponding tab will be selected. Otherwise, the first tab will be selected by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->