### PR TITLE
feat(#89): add popover group prop for group filters

### DIFF
--- a/src/components/GroupFilter.vue
+++ b/src/components/GroupFilter.vue
@@ -25,7 +25,7 @@
                   type="horizontal"
                 >
                   <template #default="{ item }">
-                    <CTPopover :trigger="item.name">
+                    <CTPopover :trigger="item.name" group="group-filters">
                       <slot :name="`filter-${item.id}`">
                         <!-- @TODO - default filter? -->
                       </slot>

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -4,7 +4,7 @@
     :class="`ct-popover ${themeClass}`"
     data-collapsible="1"
     data-collapsible-collapsed=""
-    data-collapsible-group=""
+    :data-collapsible-group="group"
     data-collapsible-duration="250"
   >
     <a
@@ -39,6 +39,10 @@ export default {
   mixins: [ThemeMixin],
 
   props: {
+    group: {
+      type: String,
+      default: undefined
+    },
     tag: {
       type: String,
       validator: (value) => ['div', 'span'].includes(value),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Adds `group` prop to `CTPopover` component to allow closing of grouped popovers.
Implements `group` prop in `CTGroupFilter` component.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `group` prop in the `CTPopover` and `Popover` components to enhance filter organization and management within the UI.
	- Improved the flexibility of the `Popover` component by allowing it to dynamically receive a group identifier for better handling of collapsible elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->