### PR TITLE
feat(#93): add disabled prop to popover

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -10,6 +10,7 @@
     <a
       :class="`ct-link ${themeClass} ct-popover__link`"
       :data-collapsible-trigger="true"
+      :disabled="disabled"
       @click="$emit('trigger')"
     >
       <slot name="trigger">
@@ -39,6 +40,10 @@ export default {
   mixins: [ThemeMixin],
 
   props: {
+    disabled: {
+      type: Boolean,
+      default: false
+    },
     group: {
       type: String,
       default: undefined


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- added disabled prop to popover

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


## Screenshots/Media:
<!--- Add any screenshots or other type of media to demonstrate your change -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `disabled` prop for the Popover component, allowing users to conditionally disable the trigger link.

- **Enhancements**
	- Improved user interaction control by enabling the disabling of the popover trigger based on the `disabled` prop value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->