### PR TITLE
feat(#156): add support for full card clickability in wrapped states

### DIFF
--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -46,20 +46,22 @@
         :value="date"
       />
 
-      <!-- Title -->
-      <CTHeading
-        v-if="title"
-        class="ct-event-card__title"
-        :level="4"
-        :theme="theme"
-      >
-        <CTLink
-          class="ct-event-card__title__link"
-          :link="link"
-          :theme="theme"
-          :text="title"
-        />
-      </CTHeading>
+       <!-- Title -->
+       <CTHeading
+         v-if="title"
+         class="ct-event-card__title"
+         :level="4"
+         :theme="theme"
+       >
+         <CTLink
+           v-if="link"
+           class="ct-event-card__title__link"
+           :link="link"
+           :theme="theme"
+           :text="title"
+         />
+         <span v-else :class="['ct-event-card__title__link', 'ct-link', themeClass]">{{ title }}</span>
+       </CTHeading>
 
       <!-- Slot: Content middle -->
       <div

--- a/src/components/NavigationCard.vue
+++ b/src/components/NavigationCard.vue
@@ -32,21 +32,23 @@
 
       <!-- @TODO - Icon -->
 
-      <!-- Title -->
-      <CTHeading
-        v-if="title"
-        class="ct-navigation-card__title"
-        :level="4"
-      >
-        <CTLink
-          class="ct-navigation-card__title__link"
-          :external="isExternal"
-          :link="link"
-          :text="title"
-          :theme="theme"
-          :icon="linkIcon"
-        />
-      </CTHeading>
+       <!-- Title -->
+       <CTHeading
+         v-if="title"
+         class="ct-navigation-card__title"
+         :level="4"
+       >
+         <CTLink
+           v-if="link"
+           class="ct-navigation-card__title__link"
+           :external="isExternal"
+           :link="link"
+           :text="title"
+           :theme="theme"
+           :icon="linkIcon"
+         />
+         <span v-else :class="['ct-navigation-card__title__link', 'ct-link', themeClass]">{{ title }}<CTIcon v-if="icon" class="ct-link__icon" :symbol="icon" /></span>
+       </CTHeading>
 
       <!-- Slot: Content middle -->
       <div
@@ -93,6 +95,10 @@ export default {
       default: undefined,
     },
     title: {
+      type: String,
+      default: undefined,
+    },
+    icon: {
       type: String,
       default: undefined,
     }

--- a/src/components/PromoCard.vue
+++ b/src/components/PromoCard.vue
@@ -52,18 +52,20 @@
         :value="date"
       />
 
-      <!-- Title -->
-      <div
-        v-if="title"
-        class="ct-promo-card__title"
-      >
-        <CTLink
-          class="ct-promo-card__title-link"
-          :link="link || '#'"
-          :text="title"
-          :theme="theme"
-        />
-      </div>
+       <!-- Title -->
+       <div
+         v-if="title"
+         class="ct-promo-card__title"
+       >
+         <CTLink
+           v-if="link"
+           class="ct-promo-card__title-link"
+           :link="link"
+           :text="title"
+           :theme="theme"
+         />
+         <span v-else :class="['ct-promo-card__title-link', 'ct-link', themeClass]">{{ title }}</span>
+       </div>
 
       <!-- Slot: Content middle -->
       <div

--- a/src/components/SubjectCard.vue
+++ b/src/components/SubjectCard.vue
@@ -28,15 +28,17 @@
         <slot name="image_over" />
       </div>
 
-      <!-- @TODO - CTHeading -->
-      <div class="ct-subject-card__title">
-        <CTLink
-          class="ct-subject-card__title-link"
-          :link="link"
-          :theme="theme"
-          :text="title"
-        />
-      </div>
+       <!-- @TODO - CTHeading -->
+       <div class="ct-subject-card__title">
+         <CTLink
+           v-if="link"
+           class="ct-subject-card__title-link"
+           :link="link"
+           :theme="theme"
+           :text="title"
+         />
+         <span v-else :class="['ct-subject-card__title-link', 'ct-link', themeClass]">{{ title }}</span>
+       </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
This PR adds support for full card clickability when cards are wrapped in link elements. Previously, only the title was clickable, limiting UX. Now, when cards are used without a :link prop (i.e., wrapped in a parent link), the title renders as a
styled span instead of a link, allowing the wrapper to handle clicks.

Changes include:
- Conditional rendering of title CTLink based on :link prop in EventCard, NavigationCard, PromoCard, SubjectCard
- Addition of icon prop to NavigationCard with conditional CTIcon rendering for wrapped states
- Proper styling classes for wrapped card titles

This resolves the need for full card clickability in consuming applications like Law Library Victoria, improving accessibility and user experience. No breaking changes; maintains backward compatibility.

Resolves: #156 

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

## Screenshots/Media:
No visual changes; functionality enhancement for wrapped usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - NavigationCard: Added optional icon prop to show an inline icon next to non-linked titles.

- Bug Fixes
  - EventCard, NavigationCard, PromoCard, SubjectCard: Titles are no longer forced to be clickable when no link is provided; they now render as plain text, preserving styling and improving accessibility and UX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->